### PR TITLE
Fixed UDKLibVW's references to directX.

### DIFF
--- a/ME3Explorer/DLCEditor2/DLCEditor2.cs
+++ b/ME3Explorer/DLCEditor2/DLCEditor2.cs
@@ -449,6 +449,18 @@ namespace ME3Explorer.DLCEditor2
             if (result == "")
                 return;
             DebugOutput.PrintLn("result : " + result);
+            FolderBrowserDialog fbd = new System.Windows.Forms.FolderBrowserDialog();
+            fbd.Description = "Please choose a folder to unpack this DLC to. Unpacking may take a few minutes.";
+            DialogResult dresult = fbd.ShowDialog();
+            if (dresult != DialogResult.OK)
+            {
+                return;
+            }
+            string unpackFolder = fbd.SelectedPath;
+            if (!unpackFolder.EndsWith("\\"))
+                unpackFolder = unpackFolder + "\\";
+            DebugOutput.PrintLn("Extracting DLC to : " + unpackFolder);
+
             result = result.Trim();
             if (result.EndsWith(";"))
                 result = result.Substring(0, result.Length - 1);
@@ -471,7 +483,7 @@ namespace ME3Explorer.DLCEditor2
                         if (DLCpath.ToLower().EndsWith(patt[j].Trim().ToLower()) && patt[j].Trim().ToLower() != "")
                         {
                             string relPath = GetRelativePath(DLCpath);
-                            string outpath = gamebase + relPath;
+                            string outpath = unpackFolder + relPath;
                             DebugOutput.PrintLn("Extracting file #" + i.ToString("d4") + ": " + outpath);
                             if (!Directory.Exists(Path.GetDirectoryName(outpath)))
                                 Directory.CreateDirectory(Path.GetDirectoryName(outpath));

--- a/UDKLibWV/UDKLibWV.csproj
+++ b/UDKLibWV/UDKLibWV.csproj
@@ -35,15 +35,15 @@
   <ItemGroup>
     <Reference Include="Microsoft.DirectX, Version=1.0.2902.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\ME3Explorer\Libraries\Microsoft.DirectX.dll</HintPath>
+      <HintPath>..\Libraries\Microsoft.DirectX.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.DirectX.Direct3D, Version=1.0.2902.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\ME3Explorer\Libraries\Microsoft.DirectX.Direct3D.dll</HintPath>
+      <HintPath>..\Libraries\Microsoft.DirectX.Direct3D.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.DirectX.Direct3DX, Version=1.0.2909.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\ME3Explorer\Libraries\Microsoft.DirectX.Direct3DX.dll</HintPath>
+      <HintPath>..\Libraries\Microsoft.DirectX.Direct3DX.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IO.RecyclableMemoryStream, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IO.RecyclableMemoryStream.1.1.0.0\lib\net45\Microsoft.IO.RecyclableMemoryStream.dll</HintPath>


### PR DESCRIPTION
DLCEditor 2 will now unpack to the specific directory instead of some random folder.
Fixes #77.
