### PR TITLE
Fixes for previous commit (fixes #136)

### DIFF
--- a/ME3Explorer/PCCEditor2/PCCEditor2.Designer.cs
+++ b/ME3Explorer/PCCEditor2/PCCEditor2.Designer.cs
@@ -1063,6 +1063,7 @@
         public System.Windows.Forms.ToolStripMenuItem saveHexChangesToolStripMenuItem;
         public System.Windows.Forms.OpenFileDialog openFileDialog;
         public Be.Windows.Forms.HexBox hb1;
+        public Be.Windows.Forms.HexBox hb2;
         public System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabel1;
         public System.Windows.Forms.ToolStripComboBox combo1;
         public System.Windows.Forms.ToolStripButton toolStripButton1;
@@ -1135,7 +1136,6 @@
         private System.Windows.Forms.ToolStripButton Button5;
         private System.Windows.Forms.TreeView treeView1;
         public System.Windows.Forms.ListBox listBox1;
-        private Be.Windows.Forms.HexBox hb2;
         private System.Windows.Forms.ToolStripMenuItem scanForCoalescedValuesToolStripMenuItem;
         private System.Windows.Forms.TextBox superclassTextBox;
         private System.Windows.Forms.Label superclassLabel;

--- a/ME3Explorer/PCCEditor2/PCCEditor2.Designer.cs
+++ b/ME3Explorer/PCCEditor2/PCCEditor2.Designer.cs
@@ -680,7 +680,7 @@
             this.tabPage3.Controls.Add(this.groupBox1);
             this.tabPage3.Location = new System.Drawing.Point(4, 22);
             this.tabPage3.Name = "tabPage3";
-            this.tabPage3.Size = new System.Drawing.Size(652, 411);
+            this.tabPage3.Size = new System.Drawing.Size(633, 414);
             this.tabPage3.TabIndex = 3;
             this.tabPage3.Text = "Info";
             this.tabPage3.UseVisualStyleBackColor = true;
@@ -697,9 +697,9 @@
             this.groupBox2.Controls.Add(this.textBox8);
             this.groupBox2.Controls.Add(this.textBox7);
             this.groupBox2.Controls.Add(this.label7);
-            this.groupBox2.Location = new System.Drawing.Point(4, 215);
+            this.groupBox2.Location = new System.Drawing.Point(4, 240);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(848, 399);
+            this.groupBox2.Size = new System.Drawing.Size(626, 171);
             this.groupBox2.TabIndex = 1;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Export data";
@@ -786,7 +786,7 @@
             this.groupBox1.Controls.Add(this.label1);
             this.groupBox1.Location = new System.Drawing.Point(4, 4);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(868, 230);
+            this.groupBox1.Size = new System.Drawing.Size(626, 230);
             this.groupBox1.TabIndex = 0;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Export header";

--- a/ME3Explorer/PCCEditor2/PCCEditor2.Designer.cs
+++ b/ME3Explorer/PCCEditor2/PCCEditor2.Designer.cs
@@ -79,6 +79,7 @@
             this.listBox1 = new System.Windows.Forms.ListBox();
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.tabPage1 = new System.Windows.Forms.TabPage();
+            this.hb1 = new Be.Windows.Forms.HexBox();
             this.tabPage2 = new System.Windows.Forms.TabPage();
             this.propGrid = new System.Windows.Forms.PropertyGrid();
             this.Script = new System.Windows.Forms.TabPage();
@@ -128,6 +129,7 @@
             this.splitContainer1.Panel2.SuspendLayout();
             this.splitContainer1.SuspendLayout();
             this.tabControl1.SuspendLayout();
+            this.tabPage1.SuspendLayout();
             this.tabPage2.SuspendLayout();
             this.Script.SuspendLayout();
             this.tabPage3.SuspendLayout();
@@ -169,7 +171,7 @@
             // loadToolStripMenuItem
             // 
             this.loadToolStripMenuItem.Name = "loadToolStripMenuItem";
-            this.loadToolStripMenuItem.Size = new System.Drawing.Size(210, 22);
+            this.loadToolStripMenuItem.Size = new System.Drawing.Size(211, 22);
             this.loadToolStripMenuItem.Text = "Load";
             this.loadToolStripMenuItem.ToolTipText = "Load an uncompressed or compressed PCC file";
             this.loadToolStripMenuItem.Click += new System.EventHandler(this.loadToolStripMenuItem_Click);
@@ -177,7 +179,7 @@
             // loadFromDLCToolStripMenuItem
             // 
             this.loadFromDLCToolStripMenuItem.Name = "loadFromDLCToolStripMenuItem";
-            this.loadFromDLCToolStripMenuItem.Size = new System.Drawing.Size(210, 22);
+            this.loadFromDLCToolStripMenuItem.Size = new System.Drawing.Size(211, 22);
             this.loadFromDLCToolStripMenuItem.Text = "Load from DLC (SFAR)";
             this.loadFromDLCToolStripMenuItem.ToolTipText = "Load a PCC from a DLC SFAR file";
             this.loadFromDLCToolStripMenuItem.Click += new System.EventHandler(this.loadFromDLCToolStripMenuItem_Click);
@@ -185,7 +187,7 @@
             // saveToolStripMenuItem
             // 
             this.saveToolStripMenuItem.Name = "saveToolStripMenuItem";
-            this.saveToolStripMenuItem.Size = new System.Drawing.Size(210, 22);
+            this.saveToolStripMenuItem.Size = new System.Drawing.Size(211, 22);
             this.saveToolStripMenuItem.Text = "Save";
             this.saveToolStripMenuItem.ToolTipText = "Save changes by appending changes to the end of the file";
             this.saveToolStripMenuItem.Click += new System.EventHandler(this.saveToolStripMenuItem_Click);
@@ -193,7 +195,7 @@
             // altSavetestingToolStripMenuItem
             // 
             this.altSavetestingToolStripMenuItem.Name = "altSavetestingToolStripMenuItem";
-            this.altSavetestingToolStripMenuItem.Size = new System.Drawing.Size(210, 22);
+            this.altSavetestingToolStripMenuItem.Size = new System.Drawing.Size(211, 22);
             this.altSavetestingToolStripMenuItem.Text = "Alt. Saving (old)";
             this.altSavetestingToolStripMenuItem.ToolTipText = "Save changes by replacing changed imports/exports/names in the same location of t" +
     "he file";
@@ -202,7 +204,7 @@
             // saveIntoDLCToolStripMenuItem
             // 
             this.saveIntoDLCToolStripMenuItem.Name = "saveIntoDLCToolStripMenuItem";
-            this.saveIntoDLCToolStripMenuItem.Size = new System.Drawing.Size(210, 22);
+            this.saveIntoDLCToolStripMenuItem.Size = new System.Drawing.Size(211, 22);
             this.saveIntoDLCToolStripMenuItem.Text = "Save into DLC (SFAR)";
             this.saveIntoDLCToolStripMenuItem.ToolTipText = "Save changes and place file into DLC SFAR file. Uses the Alt Saving method";
             this.saveIntoDLCToolStripMenuItem.Click += new System.EventHandler(this.saveIntoDLCToolStripMenuItem_Click);
@@ -210,7 +212,7 @@
             // scanForCoalescedValuesToolStripMenuItem
             // 
             this.scanForCoalescedValuesToolStripMenuItem.Name = "scanForCoalescedValuesToolStripMenuItem";
-            this.scanForCoalescedValuesToolStripMenuItem.Size = new System.Drawing.Size(210, 22);
+            this.scanForCoalescedValuesToolStripMenuItem.Size = new System.Drawing.Size(211, 22);
             this.scanForCoalescedValuesToolStripMenuItem.Text = "Scan for Coalesced Values";
             this.scanForCoalescedValuesToolStripMenuItem.ToolTipText = "Enable/Disable scanning exports for Coalesced flag. Turning this on will make all" +
     " export data be loaded, which make take a long time.";
@@ -219,12 +221,12 @@
             // toolStripMenuItem1
             // 
             this.toolStripMenuItem1.Name = "toolStripMenuItem1";
-            this.toolStripMenuItem1.Size = new System.Drawing.Size(207, 6);
+            this.toolStripMenuItem1.Size = new System.Drawing.Size(208, 6);
             // 
             // recentToolStripMenuItem
             // 
             this.recentToolStripMenuItem.Name = "recentToolStripMenuItem";
-            this.recentToolStripMenuItem.Size = new System.Drawing.Size(210, 22);
+            this.recentToolStripMenuItem.Size = new System.Drawing.Size(211, 22);
             this.recentToolStripMenuItem.Text = "Recent";
             this.recentToolStripMenuItem.ToolTipText = "Open recently opened file";
             this.recentToolStripMenuItem.Click += new System.EventHandler(this.recentToolStripMenuItem_Click);
@@ -327,14 +329,14 @@
             // exportFaceFXToolStripMenuItem
             // 
             this.exportFaceFXToolStripMenuItem.Name = "exportFaceFXToolStripMenuItem";
-            this.exportFaceFXToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.exportFaceFXToolStripMenuItem.Size = new System.Drawing.Size(110, 22);
             this.exportFaceFXToolStripMenuItem.Text = "Export";
             this.exportFaceFXToolStripMenuItem.Click += new System.EventHandler(this.exportFaceFXToolStripMenuItem_Click_1);
             // 
             // importToolStripMenuItem
             // 
             this.importToolStripMenuItem.Name = "importToolStripMenuItem";
-            this.importToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.importToolStripMenuItem.Size = new System.Drawing.Size(110, 22);
             this.importToolStripMenuItem.Text = "Import";
             this.importToolStripMenuItem.Click += new System.EventHandler(this.importToolStripMenuItem_Click);
             // 
@@ -400,7 +402,7 @@
             this.toolStripButton4});
             this.toolStrip1.Location = new System.Drawing.Point(0, 0);
             this.toolStrip1.Name = "toolStrip1";
-            this.toolStrip1.Size = new System.Drawing.Size(1031, 25);
+            this.toolStrip1.Size = new System.Drawing.Size(1002, 25);
             this.toolStrip1.TabIndex = 1;
             this.toolStrip1.Text = "toolStrip1";
             // 
@@ -441,7 +443,7 @@
             this.Button5.Image = ((System.Drawing.Image)(resources.GetObject("Button5.Image")));
             this.Button5.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.Button5.Name = "Button5";
-            this.Button5.Size = new System.Drawing.Size(61, 22);
+            this.Button5.Size = new System.Drawing.Size(62, 22);
             this.Button5.Text = "Tree View";
             this.Button5.Click += new System.EventHandler(this.Button5_Click);
             // 
@@ -511,9 +513,9 @@
             this.pb1,
             this.toolStripStatusLabel1,
             this.status2});
-            this.statusStrip1.Location = new System.Drawing.Point(0, 432);
+            this.statusStrip1.Location = new System.Drawing.Point(0, 469);
             this.statusStrip1.Name = "statusStrip1";
-            this.statusStrip1.Size = new System.Drawing.Size(1031, 22);
+            this.statusStrip1.Size = new System.Drawing.Size(1002, 22);
             this.statusStrip1.TabIndex = 2;
             this.statusStrip1.Text = "statusStrip1";
             // 
@@ -550,8 +552,8 @@
             // splitContainer1.Panel2
             // 
             this.splitContainer1.Panel2.Controls.Add(this.tabControl1);
-            this.splitContainer1.Size = new System.Drawing.Size(1031, 407);
-            this.splitContainer1.SplitterDistance = 340;
+            this.splitContainer1.Size = new System.Drawing.Size(1002, 444);
+            this.splitContainer1.SplitterDistance = 330;
             this.splitContainer1.TabIndex = 3;
             // 
             // treeView1
@@ -560,7 +562,7 @@
             this.treeView1.Font = new System.Drawing.Font("Courier New", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.treeView1.Location = new System.Drawing.Point(0, 0);
             this.treeView1.Name = "treeView1";
-            this.treeView1.Size = new System.Drawing.Size(340, 407);
+            this.treeView1.Size = new System.Drawing.Size(330, 444);
             this.treeView1.TabIndex = 1;
             this.treeView1.Visible = false;
             this.treeView1.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.treeView1_AfterSelect);
@@ -576,7 +578,7 @@
             this.listBox1.Location = new System.Drawing.Point(0, 0);
             this.listBox1.Name = "listBox1";
             this.listBox1.ScrollAlwaysVisible = true;
-            this.listBox1.Size = new System.Drawing.Size(340, 407);
+            this.listBox1.Size = new System.Drawing.Size(330, 444);
             this.listBox1.TabIndex = 0;
             this.listBox1.SelectedIndexChanged += new System.EventHandler(this.listBox1_SelectedIndexChanged_1);
             // 
@@ -594,18 +596,37 @@
             this.tabControl1.Location = new System.Drawing.Point(4, 4);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
-            this.tabControl1.Size = new System.Drawing.Size(680, 400);
+            this.tabControl1.Size = new System.Drawing.Size(641, 440);
             this.tabControl1.TabIndex = 4;
             // 
             // tabPage1
             // 
+            this.tabPage1.Controls.Add(this.hb1);
             this.tabPage1.Location = new System.Drawing.Point(4, 22);
             this.tabPage1.Name = "tabPage1";
             this.tabPage1.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage1.Size = new System.Drawing.Size(672, 374);
+            this.tabPage1.Size = new System.Drawing.Size(633, 414);
             this.tabPage1.TabIndex = 0;
             this.tabPage1.Text = "Hex Editor";
             this.tabPage1.UseVisualStyleBackColor = true;
+            // 
+            // hb1
+            // 
+            this.hb1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.hb1.BoldFont = null;
+            this.hb1.Font = new System.Drawing.Font("Courier New", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.hb1.LineInfoForeColor = System.Drawing.Color.Empty;
+            this.hb1.LineInfoVisible = true;
+            this.hb1.Location = new System.Drawing.Point(3, 3);
+            this.hb1.Name = "hb1";
+            this.hb1.ShadowSelectionColor = System.Drawing.Color.FromArgb(((int)(((byte)(100)))), ((int)(((byte)(60)))), ((int)(((byte)(188)))), ((int)(((byte)(255)))));
+            this.hb1.Size = new System.Drawing.Size(627, 405);
+            this.hb1.StringViewVisible = true;
+            this.hb1.TabIndex = 1;
+            this.hb1.UseFixedBytesPerLine = true;
+            this.hb1.VScrollBarVisible = true;
             // 
             // tabPage2
             // 
@@ -613,7 +634,7 @@
             this.tabPage2.Location = new System.Drawing.Point(4, 22);
             this.tabPage2.Name = "tabPage2";
             this.tabPage2.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage2.Size = new System.Drawing.Size(672, 374);
+            this.tabPage2.Size = new System.Drawing.Size(652, 411);
             this.tabPage2.TabIndex = 1;
             this.tabPage2.Text = "Properties";
             this.tabPage2.UseVisualStyleBackColor = true;
@@ -624,7 +645,7 @@
             this.propGrid.Dock = System.Windows.Forms.DockStyle.Fill;
             this.propGrid.Location = new System.Drawing.Point(3, 3);
             this.propGrid.Name = "propGrid";
-            this.propGrid.Size = new System.Drawing.Size(666, 368);
+            this.propGrid.Size = new System.Drawing.Size(646, 405);
             this.propGrid.TabIndex = 0;
             this.propGrid.PropertyValueChanged += new System.Windows.Forms.PropertyValueChangedEventHandler(this.propGrid_PropertyValueChanged);
             // 
@@ -633,7 +654,7 @@
             this.Script.Controls.Add(this.rtb1);
             this.Script.Location = new System.Drawing.Point(4, 22);
             this.Script.Name = "Script";
-            this.Script.Size = new System.Drawing.Size(672, 374);
+            this.Script.Size = new System.Drawing.Size(633, 414);
             this.Script.TabIndex = 2;
             this.Script.Text = "Script";
             this.Script.UseVisualStyleBackColor = true;
@@ -648,7 +669,7 @@
             this.rtb1.Location = new System.Drawing.Point(3, 3);
             this.rtb1.Name = "rtb1";
             this.rtb1.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.rtb1.Size = new System.Drawing.Size(669, 368);
+            this.rtb1.Size = new System.Drawing.Size(627, 408);
             this.rtb1.TabIndex = 2;
             this.rtb1.Text = "";
             this.rtb1.WordWrap = false;
@@ -659,7 +680,7 @@
             this.tabPage3.Controls.Add(this.groupBox1);
             this.tabPage3.Location = new System.Drawing.Point(4, 22);
             this.tabPage3.Name = "tabPage3";
-            this.tabPage3.Size = new System.Drawing.Size(672, 374);
+            this.tabPage3.Size = new System.Drawing.Size(652, 411);
             this.tabPage3.TabIndex = 3;
             this.tabPage3.Text = "Info";
             this.tabPage3.UseVisualStyleBackColor = true;
@@ -676,9 +697,9 @@
             this.groupBox2.Controls.Add(this.textBox8);
             this.groupBox2.Controls.Add(this.textBox7);
             this.groupBox2.Controls.Add(this.label7);
-            this.groupBox2.Location = new System.Drawing.Point(4, 240);
+            this.groupBox2.Location = new System.Drawing.Point(4, 215);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(663, 131);
+            this.groupBox2.Size = new System.Drawing.Size(848, 399);
             this.groupBox2.TabIndex = 1;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Export data";
@@ -918,7 +939,7 @@
             this.tabPage4.Location = new System.Drawing.Point(4, 22);
             this.tabPage4.Name = "tabPage4";
             this.tabPage4.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage4.Size = new System.Drawing.Size(672, 374);
+            this.tabPage4.Size = new System.Drawing.Size(652, 411);
             this.tabPage4.TabIndex = 4;
             this.tabPage4.Text = "Meta Data Editor";
             this.tabPage4.UseVisualStyleBackColor = true;
@@ -990,7 +1011,7 @@
             this.tabPage5.Location = new System.Drawing.Point(4, 22);
             this.tabPage5.Name = "tabPage5";
             this.tabPage5.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage5.Size = new System.Drawing.Size(672, 374);
+            this.tabPage5.Size = new System.Drawing.Size(652, 411);
             this.tabPage5.TabIndex = 5;
             this.tabPage5.Text = "Header Raw";
             this.tabPage5.UseVisualStyleBackColor = true;
@@ -998,19 +1019,24 @@
             // hb2
             // 
             this.hb2.BoldFont = null;
+            this.hb2.Dock = System.Windows.Forms.DockStyle.Fill;
             this.hb2.Font = new System.Drawing.Font("Courier New", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.hb2.LineInfoForeColor = System.Drawing.Color.Empty;
-            this.hb2.Location = new System.Drawing.Point(0, 0);
+            this.hb2.LineInfoVisible = true;
+            this.hb2.Location = new System.Drawing.Point(3, 3);
             this.hb2.Name = "hb2";
             this.hb2.ShadowSelectionColor = System.Drawing.Color.FromArgb(((int)(((byte)(100)))), ((int)(((byte)(60)))), ((int)(((byte)(188)))), ((int)(((byte)(255)))));
-            this.hb2.Size = new System.Drawing.Size(0, 0);
+            this.hb2.Size = new System.Drawing.Size(646, 405);
+            this.hb2.StringViewVisible = true;
             this.hb2.TabIndex = 0;
+            this.hb2.UseFixedBytesPerLine = true;
+            this.hb2.VScrollBarVisible = true;
             // 
             // PCCEditor2
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1031, 454);
+            this.ClientSize = new System.Drawing.Size(1002, 491);
             this.Controls.Add(this.splitContainer1);
             this.Controls.Add(this.statusStrip1);
             this.Controls.Add(this.toolStrip1);
@@ -1031,6 +1057,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
             this.splitContainer1.ResumeLayout(false);
             this.tabControl1.ResumeLayout(false);
+            this.tabPage1.ResumeLayout(false);
             this.tabPage2.ResumeLayout(false);
             this.Script.ResumeLayout(false);
             this.tabPage3.ResumeLayout(false);
@@ -1063,7 +1090,6 @@
         public System.Windows.Forms.ToolStripMenuItem saveHexChangesToolStripMenuItem;
         public System.Windows.Forms.OpenFileDialog openFileDialog;
         public Be.Windows.Forms.HexBox hb1;
-        public Be.Windows.Forms.HexBox hb2;
         public System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabel1;
         public System.Windows.Forms.ToolStripComboBox combo1;
         public System.Windows.Forms.ToolStripButton toolStripButton1;
@@ -1136,6 +1162,7 @@
         private System.Windows.Forms.ToolStripButton Button5;
         private System.Windows.Forms.TreeView treeView1;
         public System.Windows.Forms.ListBox listBox1;
+        private Be.Windows.Forms.HexBox hb2;
         private System.Windows.Forms.ToolStripMenuItem scanForCoalescedValuesToolStripMenuItem;
         private System.Windows.Forms.TextBox superclassTextBox;
         private System.Windows.Forms.Label superclassLabel;

--- a/ME3Explorer/PCCEditor2/PCCEditor2.resx
+++ b/ME3Explorer/PCCEditor2/PCCEditor2.resx
@@ -221,7 +221,7 @@
     <value>341, 17</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>75</value>
+    <value>25</value>
   </metadata>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>


### PR DESCRIPTION
Fixes issues in previous commit. Visual Studio seemed to remove variables in the designer for some reason. Contains multiple commits since I had reverted some windowing changes and gradually restored them. Changes pertain to the tabs in PCCEditor2. Should fix #136 
