### PR TITLE
Fix for ME3Explorer/ME3Explorer#227

### DIFF
--- a/ME3Explorer/Interpreter2/Interpreter2.cs
+++ b/ME3Explorer/Interpreter2/Interpreter2.cs
@@ -420,6 +420,12 @@ namespace ME3Explorer.Interpreter2
             while (run)
             {
                 PropHeader p = new PropHeader();
+                if (readerpos > memory.Length)
+                {
+                    //nothing else to interpret.
+                    run = false;
+                    continue; 
+                }
                 p.name = BitConverter.ToInt32(memory, readerpos);
                 if (!pcc.isName(p.name))
                     run = false;


### PR DESCRIPTION
Fixes the Interpreter2 scanner that could cause ME3Explorer to crash when the system runs out of memory.
