### PR TITLE
Updated build numbers to 2.0.3/accept unsafe code from AMAROK to be compiled

### DIFF
--- a/AmaroK86/AmaroK86Lib.csproj
+++ b/AmaroK86/AmaroK86Lib.csproj
@@ -33,6 +33,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="ICSharpCode.SharpZipLib">

--- a/KFreonLib/Properties/AssemblyInfo.cs
+++ b/KFreonLib/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0.2.0")]
-[assembly: AssemblyFileVersion("2.0.2.0")]
+[assembly: AssemblyVersion("2.0.3.0")]
+[assembly: AssemblyFileVersion("2.0.3.0")]

--- a/ME3Explorer/Properties/AssemblyInfo.cs
+++ b/ME3Explorer/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0.2.0")]
-[assembly: AssemblyFileVersion("2.0.2.0")]
+[assembly: AssemblyVersion("2.0.3.0")]
+[assembly: AssemblyFileVersion("2.0.3.0")]


### PR DESCRIPTION
Additionally, one should consider updating the other assembly information. It lists WV as the AssemblyCompany. One would think it would be ME3Explorer team or staff or forums or whatever these days. This information comes up when looking at the details tab of the properties page for each executable and binary and adds a distinguished professionalism to the product's binaries.

Mainly, I have this PR because I have an update for my users that will require a min version of ME3EXP and I need a commit baseline.
