### PR TITLE
Fixed preview aspect ratios

### DIFF
--- a/ME3Explorer/Meshplorer/Meshplorer.Designer.cs
+++ b/ME3Explorer/Meshplorer/Meshplorer.Designer.cs
@@ -154,35 +154,35 @@
             this.lODToolStripMenuItem.Text = "LOD";
             this.lODToolStripMenuItem.Visible = false;
             // 
-            // lOD1ToolStripMenuItem
+            // lOD0ToolStripMenuItem
             // 
-            this.lOD0ToolStripMenuItem.Name = "lOD1ToolStripMenuItem";
+            this.lOD0ToolStripMenuItem.Name = "lOD0ToolStripMenuItem";
             this.lOD0ToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F1;
-            this.lOD0ToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.lOD0ToolStripMenuItem.Size = new System.Drawing.Size(125, 22);
             this.lOD0ToolStripMenuItem.Text = "LOD 0";
             this.lOD0ToolStripMenuItem.Click += new System.EventHandler(this.lOD0ToolStripMenuItem_Click);
             // 
-            // lOD2ToolStripMenuItem
+            // lOD1ToolStripMenuItem
             // 
-            this.lOD1ToolStripMenuItem.Name = "lOD2ToolStripMenuItem";
+            this.lOD1ToolStripMenuItem.Name = "lOD1ToolStripMenuItem";
             this.lOD1ToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F2;
-            this.lOD1ToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.lOD1ToolStripMenuItem.Size = new System.Drawing.Size(125, 22);
             this.lOD1ToolStripMenuItem.Text = "LOD 1";
             this.lOD1ToolStripMenuItem.Click += new System.EventHandler(this.lOD1ToolStripMenuItem_Click);
             // 
-            // lOD3ToolStripMenuItem
+            // lOD2ToolStripMenuItem
             // 
-            this.lOD2ToolStripMenuItem.Name = "lOD3ToolStripMenuItem";
+            this.lOD2ToolStripMenuItem.Name = "lOD2ToolStripMenuItem";
             this.lOD2ToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F3;
-            this.lOD2ToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.lOD2ToolStripMenuItem.Size = new System.Drawing.Size(125, 22);
             this.lOD2ToolStripMenuItem.Text = "LOD 2";
             this.lOD2ToolStripMenuItem.Click += new System.EventHandler(this.lOD2ToolStripMenuItem_Click);
             // 
-            // lOD4ToolStripMenuItem
+            // lOD3ToolStripMenuItem
             // 
-            this.lOD3ToolStripMenuItem.Name = "lOD4ToolStripMenuItem";
+            this.lOD3ToolStripMenuItem.Name = "lOD3ToolStripMenuItem";
             this.lOD3ToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F4;
-            this.lOD3ToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.lOD3ToolStripMenuItem.Size = new System.Drawing.Size(125, 22);
             this.lOD3ToolStripMenuItem.Text = "LOD 3";
             this.lOD3ToolStripMenuItem.Click += new System.EventHandler(this.lOD3ToolStripMenuItem_Click);
             // 
@@ -197,7 +197,7 @@
             this.toolStripMenuItem1,
             this.importOptionsToolStripMenuItem});
             this.transferToolStripMenuItem.Name = "transferToolStripMenuItem";
-            this.transferToolStripMenuItem.Size = new System.Drawing.Size(62, 20);
+            this.transferToolStripMenuItem.Size = new System.Drawing.Size(61, 20);
             this.transferToolStripMenuItem.Text = "Transfer";
             // 
             // exportToPSKToolStripMenuItem
@@ -428,6 +428,7 @@
             this.pb1.Size = new System.Drawing.Size(197, 321);
             this.pb1.TabIndex = 0;
             this.pb1.TabStop = false;
+            this.pb1.Resize += new System.EventHandler(this.pb1_Resize);
             // 
             // hb1
             // 

--- a/ME3Explorer/Meshplorer/Meshplorer.cs
+++ b/ME3Explorer/Meshplorer/Meshplorer.cs
@@ -38,6 +38,7 @@ namespace ME3Explorer.Meshplorer
                 Preview3D.Cubes = new List<Preview3D.DXCube>();
                 Preview3D.Cubes.Add(c);
                 timer1.Enabled = true;
+                pb1_Resize(null, null); // set correct aspect ratio
             }
         }
 
@@ -836,6 +837,11 @@ namespace ME3Explorer.Meshplorer
                 return;
             pcc.save();
             MessageBox.Show("Done");
+        }
+
+        private void pb1_Resize(object sender, EventArgs e)
+        {
+            Preview3D.aspect = (float) pb1.Width / pb1.Height;
         }
     }
 }

--- a/ME3Explorer/Meshplorer/Preview3D.cs
+++ b/ME3Explorer/Meshplorer/Preview3D.cs
@@ -28,6 +28,7 @@ namespace ME3Explorer.Meshplorer
         public static StaticMesh StatMesh;
         private static SkeletalMesh skelMesh;
         public static int LOD;
+        public static float aspect = 1.0f;
 
         public static SkeletalMesh SkelMesh
         {
@@ -182,7 +183,7 @@ namespace ME3Explorer.Meshplorer
                         fAngle = iTime * (2.0f * (float)Math.PI) / 10000.0f;
                     device.Transform.World = Matrix.RotationZ(fAngle);
                     device.Transform.View = Matrix.LookAtLH(new Vector3(0.0f, CamDistance, CamDistance / 2) + CamOffset, new Vector3(0, 0, 0) + CamOffset, new Vector3(0.0f, 0.0f, 1.0f));
-                    device.Transform.Projection = Matrix.PerspectiveFovLH((float)Math.PI / 4, 1.0f, 1.0f, 100000.0f);
+                    device.Transform.Projection = Matrix.PerspectiveFovLH((float)Math.PI / 4, aspect, 1.0f, 100000.0f);
                     
                     //device.SetTexture(0, null);
                     device.VertexFormat = CustomVertex.PositionColored.Format;

--- a/ME3Explorer/Meshplorer2/Meshplorer2.Designer.cs
+++ b/ME3Explorer/Meshplorer2/Meshplorer2.Designer.cs
@@ -97,7 +97,7 @@
             this.scanToolStripMenuItem,
             this.saveToolStripMenuItem});
             this.globalTreeToolStripMenuItem.Name = "globalTreeToolStripMenuItem";
-            this.globalTreeToolStripMenuItem.Size = new System.Drawing.Size(79, 20);
+            this.globalTreeToolStripMenuItem.Size = new System.Drawing.Size(78, 20);
             this.globalTreeToolStripMenuItem.Text = "Global Tree";
             // 
             // loadToolStripMenuItem
@@ -137,7 +137,7 @@
             this.previewWithTreeToolStripMenuItem.CheckOnClick = true;
             this.previewWithTreeToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.previewWithTreeToolStripMenuItem.Name = "previewWithTreeToolStripMenuItem";
-            this.previewWithTreeToolStripMenuItem.Size = new System.Drawing.Size(167, 22);
+            this.previewWithTreeToolStripMenuItem.Size = new System.Drawing.Size(166, 22);
             this.previewWithTreeToolStripMenuItem.Text = "Preview with Tree";
             // 
             // rotateToolStripMenuItem
@@ -146,14 +146,14 @@
             this.rotateToolStripMenuItem.CheckOnClick = true;
             this.rotateToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.rotateToolStripMenuItem.Name = "rotateToolStripMenuItem";
-            this.rotateToolStripMenuItem.Size = new System.Drawing.Size(167, 22);
+            this.rotateToolStripMenuItem.Size = new System.Drawing.Size(166, 22);
             this.rotateToolStripMenuItem.Text = "Rotate";
             this.rotateToolStripMenuItem.Click += new System.EventHandler(this.rotateToolStripMenuItem_Click);
             // 
             // importBonesToolStripMenuItem
             // 
             this.importBonesToolStripMenuItem.Name = "importBonesToolStripMenuItem";
-            this.importBonesToolStripMenuItem.Size = new System.Drawing.Size(167, 22);
+            this.importBonesToolStripMenuItem.Size = new System.Drawing.Size(166, 22);
             this.importBonesToolStripMenuItem.Text = "Import Bones";
             this.importBonesToolStripMenuItem.Click += new System.EventHandler(this.importBonesToolStripMenuItem_Click);
             // 
@@ -162,7 +162,7 @@
             this.transferToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.importFromUDKToolStripMenuItem});
             this.transferToolStripMenuItem.Name = "transferToolStripMenuItem";
-            this.transferToolStripMenuItem.Size = new System.Drawing.Size(62, 20);
+            this.transferToolStripMenuItem.Size = new System.Drawing.Size(61, 20);
             this.transferToolStripMenuItem.Text = "Transfer";
             // 
             // importFromUDKToolStripMenuItem
@@ -278,6 +278,7 @@
             this.pb1.TabIndex = 0;
             this.pb1.TabStop = false;
             this.pb1.MouseHover += new System.EventHandler(this.pb1_MouseHover);
+            this.pb1.Resize += new System.EventHandler(this.pb1_Resize);
             // 
             // treeView2
             // 

--- a/ME3Explorer/Meshplorer2/Meshplorer2.cs
+++ b/ME3Explorer/Meshplorer2/Meshplorer2.cs
@@ -477,6 +477,7 @@ namespace ME3Explorer.Meshplorer2
         private void Meshplorer2_Load(object sender, EventArgs e)
         {
             this.pb1.MouseWheel += MouseWheelHandler;
+            pb1_Resize(null, null); // set aspect ratio
         }
 
         private void MouseWheelHandler(object sender, MouseEventArgs e)
@@ -795,6 +796,11 @@ namespace ME3Explorer.Meshplorer2
         {
             Renderer.STM?.pcc.Dispose();
             Renderer.SKM?.Owner.Dispose();
+        }
+
+        private void pb1_Resize(object sender, EventArgs e)
+        {
+            Renderer.aspect = (float)pb1.Width / pb1.Height;
         }
     }
 }

--- a/ME3Explorer/Meshplorer2/Renderer.cs
+++ b/ME3Explorer/Meshplorer2/Renderer.cs
@@ -29,6 +29,7 @@ namespace ME3Explorer.Meshplorer2
         public static StaticMesh STM;
         public static SkeletalMesh SKM;
         public static int LOD;
+        public static float aspect = 1.0f;
 
         public static void Refresh()
         {
@@ -94,7 +95,7 @@ namespace ME3Explorer.Meshplorer2
                     fAngle = iTime * (2.0f * (float)Math.PI) / 10000.0f;
                 device.Transform.World = Matrix.RotationZ(fAngle);
                 device.Transform.View = Matrix.LookAtLH(new Vector3(0.0f, CamDistance, CamDistance / 2) + CamOffset, new Vector3(0, 0, 0) + CamOffset, new Vector3(0.0f, 0.0f, 1.0f));
-                device.Transform.Projection = Matrix.PerspectiveFovLH((float)Math.PI / 4, 1.0f, 1.0f, 100000.0f);
+                device.Transform.Projection = Matrix.PerspectiveFovLH((float)Math.PI / 4, aspect, 1.0f, 100000.0f);
                 device.SetTexture(0, null);
                 RenderCoordsystem(device);
                 device.VertexFormat = CustomVertex.PositionColored.Format;


### PR DESCRIPTION
Fixed the aspect ratios of the 3D previews in Meshplorer and Meshplorer2. No more stretched turians.

![image](https://cloud.githubusercontent.com/assets/4462127/20090085/d3655860-a53f-11e6-851a-75cc03ecedfd.png)

Fixes ME3Explorer/ME3Explorer#450

I noticed that the 3d preview code is copy-pasted from Meshplorer into Meshplorer2 with a different class name. It also uses the old Direct3D fixed-function pipeline. Is there a reason or should it be cleaned up?